### PR TITLE
fix: Linux support for localnet script

### DIFF
--- a/localnet/build-docker.sh
+++ b/localnet/build-docker.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-docker-compose -f localnet/docker-compose.yml build
+docker compose -f localnet/docker-compose.yml build

--- a/localnet/init-configs-localnet.sh
+++ b/localnet/init-configs-localnet.sh
@@ -63,35 +63,71 @@ function init_localtestnet() {
 }
 
 function configure_app() {
-    # Configure app settings
-    sed -i '' '/\[api\]/,+3 s/enable = false/enable = true/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/address = "tcp:\/\/localhost:1317"/address = "tcp:\/\/0.0.0.0:1317"/' $MAIN_PATH_CONFIG/app.toml
-    # sed -i '' 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/address = "localhost:9090"/address = "0.0.0.0:9090"/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' '/\[grpc-web\]/,+7 s/address = "localhost:9091"/address = "0.0.0.0:9091"/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/pruning = "default"/pruning = "nothing"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "10'$BASE_DENOM'"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' '/\[telemetry\]/,+8 s/enabled = false/enabled = true/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' '/\[telemetry\]/,+20 s/prometheus-retention-time = 0/prometheus-retention-time = 60/' $MAIN_PATH_CONFIG/app.toml
-    sed -i '' '/global-labels = \[/a\
-  \["chain_id", "'$CHAIN_ID'"\],
-' $MAIN_PATH_CONFIG/app.toml
+    if [[ "$OSTYPE" == "darwin"* ]]; then
 
-    sed -i '' 's/timeout_propose = ".*"/timeout_propose = "3s"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_propose_delta = ".*"/timeout_propose_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_prevote = ".*"/timeout_prevote = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_prevote_delta = ".*"/timeout_prevote_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_precommit = ".*"/timeout_precommit = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_precommit_delta = ".*"/timeout_precommit_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
-    sed -i '' 's/timeout_commit = ".*"/timeout_commit = "5s"/g'  $MAIN_PATH_CONFIG/app.toml
+        # Configure app settings
+        sed -i '' '/\[api\]/,+3 s/enable = false/enable = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/address = "tcp:\/\/localhost:1317"/address = "tcp:\/\/0.0.0.0:1317"/' $MAIN_PATH_CONFIG/app.toml
+        # sed -i '' 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/address = "localhost:9090"/address = "0.0.0.0:9090"/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' '/\[grpc-web\]/,+7 s/address = "localhost:9091"/address = "0.0.0.0:9091"/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/pruning = "default"/pruning = "nothing"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "10'$BASE_DENOM'"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' '/\[telemetry\]/,+8 s/enabled = false/enabled = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' '/\[telemetry\]/,+20 s/prometheus-retention-time = 0/prometheus-retention-time = 60/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '' '/global-labels = \[/a\
+    \["chain_id", "'$CHAIN_ID'"\],
+    ' $MAIN_PATH_CONFIG/app.toml
+
+        sed -i '' 's/timeout_propose = ".*"/timeout_propose = "3s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_propose_delta = ".*"/timeout_propose_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_prevote = ".*"/timeout_prevote = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_prevote_delta = ".*"/timeout_prevote_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_precommit = ".*"/timeout_precommit = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_precommit_delta = ".*"/timeout_precommit_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '' 's/timeout_commit = ".*"/timeout_commit = "5s"/g'  $MAIN_PATH_CONFIG/app.toml
 
 
-    # configure config settings
-    sed -i '' 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g'  $MAIN_PATH_CONFIG/config.toml
-    sed -i '' 's/proxy_app = "tcp:\/\/127.0.0.1:26658"/proxy_app = "tcp:\/\/127.0.0.1:26658"/g'  $MAIN_PATH_CONFIG/config.toml
-    sed -i '' 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["*"\]/g'  $MAIN_PATH_CONFIG/config.toml
-    sed -i '' 's/max_num_inbound_peers = 40/max_num_inbound_peers = 120/g'  $MAIN_PATH_CONFIG/config.toml
-    sed -i '' 's/max_num_outbound_peers = 10/max_num_outbound_peers = 60/g'  $MAIN_PATH_CONFIG/config.toml
+        # configure config settings
+        sed -i '' 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i '' 's/proxy_app = "tcp:\/\/127.0.0.1:26658"/proxy_app = "tcp:\/\/127.0.0.1:26658"/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i '' 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["*"\]/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i '' 's/max_num_inbound_peers = 40/max_num_inbound_peers = 120/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i '' 's/max_num_outbound_peers = 10/max_num_outbound_peers = 60/g'  $MAIN_PATH_CONFIG/config.toml
+
+    else
+
+        # Configure app settings
+        sed -i '/\[api\]/,+3 s/enable = false/enable = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/address = "tcp:\/\/localhost:1317"/address = "tcp:\/\/0.0.0.0:1317"/' $MAIN_PATH_CONFIG/app.toml
+        # sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/address = "localhost:9090"/address = "0.0.0.0:9090"/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '/\[grpc-web\]/,+7 s/address = "localhost:9091"/address = "0.0.0.0:9091"/' $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/pruning = "default"/pruning = "nothing"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "10'$BASE_DENOM'"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i '/\[telemetry\]/,+8 s/enabled = false/enabled = true/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '/\[telemetry\]/,+20 s/prometheus-retention-time = 0/prometheus-retention-time = 60/' $MAIN_PATH_CONFIG/app.toml
+        sed -i '/global-labels = \[/a\
+    \["chain_id", "'$CHAIN_ID'"\],
+    ' $MAIN_PATH_CONFIG/app.toml
+
+        sed -i 's/timeout_propose = ".*"/timeout_propose = "3s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_propose_delta = ".*"/timeout_propose_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_prevote = ".*"/timeout_prevote = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_prevote_delta = ".*"/timeout_prevote_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_precommit = ".*"/timeout_precommit = "1s"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_precommit_delta = ".*"/timeout_precommit_delta = "500ms"/g'  $MAIN_PATH_CONFIG/app.toml
+        sed -i 's/timeout_commit = ".*"/timeout_commit = "5s"/g'  $MAIN_PATH_CONFIG/app.toml
+
+
+        # configure config settings
+        sed -i 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i 's/proxy_app = "tcp:\/\/127.0.0.1:26658"/proxy_app = "tcp:\/\/127.0.0.1:26658"/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["*"\]/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i 's/max_num_inbound_peers = 40/max_num_inbound_peers = 120/g'  $MAIN_PATH_CONFIG/config.toml
+        sed -i 's/max_num_outbound_peers = 10/max_num_outbound_peers = 60/g'  $MAIN_PATH_CONFIG/config.toml
+
+    fi
 }
 
 function update_genesis_json() {
@@ -235,8 +271,14 @@ function configure_validator() {
     local new_persistent_peers=$(IFS=','; echo "${filtered_parts[*]}")
 
     echo "Validator $moniker persistent_peers: $new_persistent_peers"
-    sed -i '' "s/\(persistent_peers *= *\"\).*\(\" *\)/\1$new_persistent_peers\2/" $validator_home/config/config.toml
-    sed -i '' 's/moniker = "localtestnet"/moniker = "'$moniker'"/g'  $validator_home/config/config.toml
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/\(persistent_peers *= *\"\).*\(\" *\)/\1$new_persistent_peers\2/" $validator_home/config/config.toml
+        sed -i '' 's/moniker = "localtestnet"/moniker = "'$moniker'"/g'  $validator_home/config/config.toml
+    else
+        sed -i "s/\(persistent_peers *= *\"\).*\(\" *\)/\1$new_persistent_peers\2/" $validator_home/config/config.toml
+        sed -i 's/moniker = "localtestnet"/moniker = "'$moniker'"/g'  $validator_home/config/config.toml
+    fi
+    
 
     local key=$(gala keys unsafe-export-eth-key --keyring-backend test --keyring-dir ./$MAIN_PATH_HOME $moniker)
     yes '00000000' | gala keys unsafe-import-eth-key --keyring-backend test --keyring-dir ./$MAIN_PATH_HOME/validators/$moniker $moniker $key --chain-id $CHAIN_ID

--- a/localnet/run-validators.sh
+++ b/localnet/run-validators.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd localnet && docker-compose -f docker-compose.yml up -d
+cd localnet && docker compose -f docker-compose.yml up -d

--- a/localnet/staking-research.md
+++ b/localnet/staking-research.md
@@ -229,7 +229,7 @@ sed -i '' 's/moniker = "localtestnet"/moniker = "'$VALIDATOR_MONIKER'"/g'  $VALI
 # Run the nodes
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 # Test staking delegation


### PR DESCRIPTION
On Linux:
```
make localnet-build
...
./localnet/build-docker.sh: line 17: docker-compose: command not found

# Version I'm running:
docker compose version
Docker Compose version v2.26.1
```

```
make localnet-init
# Got a lot errors in the output...
sed: can't read s/\(persistent_peers *= *"\).*\(" *\)/\1 07a2d88bc6e4ccd69b5244af04d01346d393ba20@192.168.20.2:26656,1063b70946b67f490269ec20587c45a148dd129b@192.168.20.3:26656\2/: No such file or directory
sed: can't read s/moniker = "localtestnet"/moniker = "validator03"/g: No such file or directory
```

I've add check for `$OSTYPE` variable and replaced `docker-compose` -> `docker compose`.